### PR TITLE
Sync docs with sourcebans-pp 1.8.x

### DIFF
--- a/content/docs/could_not_find_driver.md
+++ b/content/docs/could_not_find_driver.md
@@ -10,7 +10,7 @@ toc = true
 
 ### Web
 
-* Ensure you have installed the mysql extension of your PHP version (Ex: <samp>php7.2-mysql</samp>)
+* Ensure you have installed the mysql extension of your PHP version (Ex: <samp>php8.2-mysql</samp>, replace `8.2` with whichever PHP version you have installed)
 * Ensure `pdo_mysql` module is loaded, check `phpinfo()` for this
 
 ### Plugin

--- a/content/docs/debugging_connection.md
+++ b/content/docs/debugging_connection.md
@@ -18,12 +18,6 @@ toc = true
 
 * You can use RCON through in-game console, if not view [TCP Error](#tcp-error) below
 
-### "Error connecting" in server list with current 1.6 release
-
-If you're using the current release 1.6 and experiencing connection issues in the server list (although everything looks fine in the debug tool), you should try and install the latest development version (1.x branch on GitHub). 
-
-Note: You need to use Composer for the latest development version.
-
 ### Using the debug tool
 
 In SourceBans++'s root directory, there's a connection debug tool named `sb_debug_connection.php`
@@ -35,9 +29,9 @@ Edit this section of that file with the corresponding server info
  * Config part
  * Change to IP and port of the gameserver you want to test
  */
-$serverip   = "";
-$serverport = 27015;
-$serverrcon = ""; // You only need to specify this, if you want to test the rcon tcp connection either! Leave blank if it's only the serverinfo erroring.
+$serverip = "";
+$serverport = ""; // Defaults to 27015 if left empty
+$serverrcon = ""; // Leave empty if you're only testing the serverinfo connection
 ```
 
 Once complete, navigate to the file in your browser, and if done properly it will attempt to connect to the specified server.

--- a/content/docs/discord_forward_setup.md
+++ b/content/docs/discord_forward_setup.md
@@ -22,8 +22,24 @@ toc = true
 
 ### Configuring
 
-* Add the convar `sbpp_discord_banhook` and assign the value of the Discord webhook link for where you want ban messages to go
+After loading the plugin once, SourceMod auto-generates `cfg/sourcemod/sbpp_discord.cfg` containing every convar below. Edit that file (or copy the convars to `autoexec.cfg`) and set the webhook URLs you want to use. Leave any hook empty to disable that channel.
 
-* Add the convar `sbpp_discord_reporthook` and assign the value of the Discord webhook link for where you want report messages to go (If missing, it will default to `sbpp_discord_banhook`'s convar value)
+#### Webhook endpoints
 
-Make sure to put these convars in an executable configuration file (preferably `autoexec.cfg`). Please also keep in mind that this only pushes the notifications if action is taken in-game, it has no affect if you - for example - ban someone on the web panel.
+* `sbpp_discord_banhook` — webhook for ban events
+
+* `sbpp_discord_reporthook` — webhook for in-game reports
+
+* `sbpp_discord_commshook` — webhook for communication blocks (mute/gag)
+
+#### Appearance & links
+
+* `sbpp_discord_username` — username shown on the webhook message (default: `Sourcebans++`)
+
+* `sbpp_discord_pp_url` — URL to a profile picture used by the webhook
+
+* `sbpp_website_url` — base URL of your SourceBans++ web panel; embeds will link admins/players back to it when set
+
+* `sbpp_discord_roleid` — Discord role ID to mention when a report comes in. Leave empty to disable the mention
+
+Please also keep in mind that this only pushes the notifications if action is taken in-game, it has no effect if you — for example — ban someone on the web panel.

--- a/content/docs/mariadb.md
+++ b/content/docs/mariadb.md
@@ -1,56 +1,71 @@
 +++
 title = "MariaDB"
-description = "Setting up a MariaDB server on Ubuntu 16.04 LTS"
+description = "Setting up a MariaDB server on Ubuntu LTS"
 date = 2018-02-18T20:30:47-05:00
 weight = 23
 draft = false
-bref = "This guide will walk you through on setting up a MariaDB server on Ubuntu 16.04 LTS"
+bref = "This guide will walk you through on setting up a MariaDB server on Ubuntu LTS"
 toc = true
 +++
 
-### Adding Repo
+SourceBans++ requires MariaDB >= 10.0 (or MySQL >= 5.6). The instructions below target current Ubuntu LTS releases (22.04 / 24.04) and install the MariaDB 10.11 LTS series.
+
+### Option A: Install from the Ubuntu repository
+
+Recent Ubuntu LTS releases ship a recent enough MariaDB by default and this is the simplest path:
 
 ```
-sudo apt-get install software-properties-common
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-sudo add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu xenial main'
-sudo apt-get update
+sudo apt update
+sudo apt install mariadb-server
 ```
 
-### Installing
+### Option B: Install from MariaDB's official repository
+
+Use this if you want a newer release than your distro provides. The legacy `apt-key adv` approach is deprecated; use `signed-by` instead.
 
 ```
-sudo apt-get install mariadb-server
+sudo apt install curl gnupg ca-certificates apt-transport-https
+sudo curl -o /etc/apt/keyrings/mariadb-keyring.pgp 'https://mariadb.org/mariadb_release_signing_key.pgp'
+echo "deb [signed-by=/etc/apt/keyrings/mariadb-keyring.pgp] https://deb.mariadb.org/10.11/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/mariadb.list
+sudo apt update
+sudo apt install mariadb-server
 ```
+
+The official [MariaDB Repository Configuration Tool](https://mariadb.org/download/?t=repo-config) can generate the same snippet for any distro/version.
 
 ### Setup
 
-Run `mysql_secure_installation`
+Run `sudo mysql_secure_installation`
 
 ### Configuring
 
+Skip this section if your web panel and game servers connect to the database from the same host (`localhost`).
+
 1.  Navigate to your MariaDB config (Ex: <samp>/etc/mysql/mariadb.conf.d/50-server.cnf</samp>)
 
-2.  Comment out `bind-address` by prefixing it with a `#`, so it looks like `#bind-address = 127.0.0.1`
+2.  Either comment out `bind-address` by prefixing it with a `#`, or set it to `0.0.0.0` (IPv4) or `::` (IPv4 + IPv6) to listen on all interfaces
 
-3.  Restart MySQL via `sudo systemctl restart mysql`
+3.  Restart MariaDB via `sudo systemctl restart mariadb`
 
 ### Granting Permission
 
-Sign in to MySQL shell via `sudo mysql -u root -p` and enter your password
+Sign in to MariaDB shell via `sudo mariadb -u root -p` (or `sudo mysql -u root -p`) and enter your password
 
 Run the following, adjusting it to suit your own needs
 
 * <mark>Username</mark> - The user you wish to create
 
-* <mark>Host</mark> - The host you wish to whitelist
+* <mark>Host</mark> - The host you wish to whitelist (e.g. `localhost`, an IP, or `%` for any host)
 
 * <mark>Password</mark> - The password to use for the user creation
 
 ```
-GRANT ALL PRIVILEGES ON *.* TO 'USERNAME'@'HOST' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
+CREATE USER 'USERNAME'@'HOST' IDENTIFIED BY 'PASSWORD';
+GRANT ALL PRIVILEGES ON `DATABASENAME`.* TO 'USERNAME'@'HOST';
 FLUSH PRIVILEGES;
 ```
+
+The combined `GRANT ... IDENTIFIED BY ...` syntax is removed in MariaDB 10.4+ / MySQL 8+, so create the user first and grant privileges in a second statement. Granting on a specific database (rather than `*.*`) keeps the principle of least privilege.
 
 ### Done!
 

--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -14,18 +14,24 @@ Before we get started, let's make sure you meet these following requirements:
 
 * Web
 
-  * A working MySQL/[MariaDB](/docs/mariadb) database
+  * A working MySQL (>= 5.6) or [MariaDB](/docs/mariadb) (>= 10.0) database
 
-  * PHP Version >= 5.6 (and PHP Version < 7.4 for SB++ 1.6.3 release)
-    * GMP extension (for A2S queries)
+  * PHP Version >= 8.2
+    * `memory_limit` >= 64M
+    * GMP extension
+    * PDO + `pdo_mysql`, OpenSSL, and XML extensions
+
+  * If installing from the `main` (development) branch, [Composer](https://getcomposer.org/) is required to pull web dependencies. Release archives ship with these pre-bundled.
 
 * Game
 
-  * Sourcemod >= 1.7
+  * SourceMod >= 1.11 (1.12 stable recommended)
 
   * Metamod: Source
 
   If you're using Cloudflare, Rocket Loader must be disabled otherwise SourceBans++ will become unresponsive.
+
+  > Note: if you are still on SB++ 1.6.x or older, see the [Updating](/docs/updating) guide before installing — these versions only support PHP < 7.4 and pre-1.11 SourceMod.
 
 ### Uploading
 
@@ -72,8 +78,6 @@ Navigate to your Sourcebans++ installer (`example.com/install`) to begin install
     - <mark>Table Prefix</mark> - The prefix you want the SourceBans++ tables to use, useful if there are name collisions, otherwise, leave it at default
 
     - <mark>Steam API Key</mark> - Your Steam API key, which can be obtained <a href="https://steamcommunity.com/dev/apikey" target="_blank_">here</a>
-
-    - <mark>SourceBans URL</mark> - Your SourceBans site with <samp>protocol</samp> included! (Ex: `https://example.com`), the <samp>http://</samp> or <samp>https://</samp> is <em>required</em>
 
     - <mark>SourceBans EMail</mark> - The email address to send password reset and/or ban submissions from, leave empty if you don't have one to use and don't plan to use it
 

--- a/content/docs/translating.md
+++ b/content/docs/translating.md
@@ -24,10 +24,10 @@ toc = true
         define('theme_author', "IceMan, SourceBans++ Dev Team");
 
         // Set the version of the theme here
-        define('theme_version', "1.5.5-dev");
+        define('theme_version', "1.8.0-dev");
 
         // Set the link of the theme here
-        define('theme_link', "https://sbpp.sarabveer.me/");
+        define('theme_link', "https://github.com/sbpp/sourcebans-pp");
 
         // Set the screenshot filename for your theme (must be inside your theme folder)
         // Must be:  250px wide  X 170px High
@@ -38,11 +38,13 @@ toc = true
 
 5.  Modify the body content of the file
 
+> Note: SourceBans++ 1.7.0+ uses Smarty 5, which dropped the `{php}` tag. Custom themes that previously used `{php}` must switch to the [`{load_template}`](https://github.com/sbpp/sourcebans-pp/blob/main/web/includes/SmartyCustomFunctions.php) tag.
+
 ### Plugin
 
 1.  Navigate to SourceMod's `translations` directory
 
-2.  The files you will need to modify are <samp>sourcebans.phrases.txt</samp>, <samp>sourcecomms.phrases.txt</samp>, and <samp>sourcesleuth.phrases.txt</samp>
+2.  The files you will need to modify are <samp>sbpp_main.phrases.txt</samp>, <samp>sbpp_comms.phrases.txt</samp>, <samp>sbpp_sleuth.phrases.txt</samp>, <samp>sbpp_report.phrases.txt</samp>, and <samp>sbpp_checker.phrases.txt</samp>
 
 3.  Within `Phrases` key section, for each sub key sections, append a key value pair, with the two letter language code being the key and the value being the translation (If `#format` kv pair is present, be sure to follow it)
 

--- a/content/docs/updating.md
+++ b/content/docs/updating.md
@@ -26,6 +26,20 @@ Download the latest zip-archive from the <a href="https://github.com/sbpp/source
 
 6. After it displays <mark>Installation up-to-date.</mark>, delete <mark>updater</mark> directory and you are done
 
+### Web Panel (Upgrading from 1.6.x or 1.7.0 to 1.8.x)
+
+1.7.0+ requires PHP >= 8.2 (see [Quickstart](/docs/quickstart)) and adds a `SB_SECRET_KEY` value in <mark>config.php</mark> used by the JWT-based session manager. Existing installs need to populate it before logging in.
+
+1. Make sure your host is on PHP >= 8.2 before uploading the new files
+
+2. Follow the regular [Web Panel](#web-panel) steps above
+
+3. Navigate to <samp>example.com/upgrade.php</samp> in your browser. The script will append `SB_SECRET_KEY` to <mark>config.php</mark> and confirm with <mark>config.php updated correctly.</mark>
+
+4. Delete <mark>upgrade.php</mark> from your server when done — it can leak sensitive information if left exposed
+
+5. If you use a custom theme, note that Smarty 5 dropped the `{php}` tag — use the [`{load_template}`](https://github.com/sbpp/sourcebans-pp/blob/main/web/includes/SmartyCustomFunctions.php) tag instead
+
 ### Plugin
 
 1. Upload and overwrite all contents in <mark>game</mark> to your root game directory (Ex: <samp>tf</samp>, <samp>cs</samp>, etc)


### PR DESCRIPTION
## Summary

Combed through `content/docs/` and cross-referenced against the upstream [`sbpp/sourcebans-pp`](https://github.com/sbpp/sourcebans-pp) repo (latest release **1.8.2**, May 2026). Updated the stale facts so the install and maintenance guides match what the current code actually does.

### Files changed

- **quickstart.md** — PHP `>= 5.6` → `>= 8.2`; SourceMod `>= 1.7` → `>= 1.11` (1.12 stable recommended); pin MySQL `>= 5.6` / MariaDB `>= 10`; mention `memory_limit`, GMP/PDO/OpenSSL/XML extensions; note Composer for the `main` branch; remove the "SourceBans URL" installer field — it was removed from `web/install/template/page.2.php`.
- **updating.md** — add an "Upgrading from 1.6.x or 1.7.0 to 1.8.x" section covering `upgrade.php` (`SB_SECRET_KEY` for the JWT session manager) and the Smarty 5 `{php}` → `{load_template}` change for custom themes.
- **mariadb.md** — replace the Ubuntu 16.04 / MariaDB 10.2 instructions with current Ubuntu LTS guidance and the MariaDB 10.11 LTS series; swap the deprecated `apt-key adv` flow for a `signed-by` keyring; split `CREATE USER` from `GRANT` now that the combined `... IDENTIFIED BY ...` syntax is gone in MariaDB 10.4+ / MySQL 8+.
- **could_not_find_driver.md** — `php7.2-mysql` → `php8.2-mysql` in the example.
- **debugging_connection.md** — drop the obsolete "current 1.6 release" workaround and align the sample `$serverport` block with the current `sb_debug_connection.php`.
- **discord_forward_setup.md** — add `sbpp_discord_commshook` plus the `username` / `pp_url` / `website_url` / `roleid` convars introduced in `sbpp_discord` plugin v1.2.0; note that `AutoExecConfig` generates `cfg/sourcemod/sbpp_discord.cfg`.
- **translating.md** — bump the `theme.conf.php` example to `1.8.0-dev` with the current GitHub URL; rename the plugin translation files to the `sbpp_*` naming (`sbpp_main`, `sbpp_comms`, `sbpp_sleuth`, `sbpp_report`, `sbpp_checker`); flag the Smarty 5 `{php}` removal.

### Sources cross-referenced

- `sbpp/sourcebans-pp` README, CHANGELOG, `web/composer.json`
- `web/install/template/page.{1..6}.php`, `web/sb_debug_connection.php`, `web/upgrade.php`, `web/themes/default/theme.conf.php`
- `game/addons/sourcemod/translations/`, `game/addons/sourcemod/configs/sourcebans/sourcebans.cfg`
- `sbpp/discord-forward` plugin source (v1.2.0)

### Out of scope

- Blog posts (point-in-time release notes — not retroactively edited). 1.8.0 / 1.8.1 / 1.8.2 release announcements aren't in `content/blog/` yet; happy to add one in a follow-up if wanted.
- `adding_server.md`, `browser_freeze.md`, `database_errors.md`, `inquiries.md`, `ports.md`, `removing_default_message.md`, `faq/_index.md` — checked, still accurate.

## Test plan

- [ ] Build the site locally with Hugo and verify all docs pages render
- [ ] Click through the cross-doc links (`/docs/mariadb`, `/docs/updating`, etc.) on the rendered site
- [ ] Verify the new MariaDB install snippet works on a current Ubuntu LTS
- [ ] Sanity-check the upgrade.php instructions by running it on a 1.7.0 install