### PR TITLE
docs(deploy): describe new PAT-based dispatch credential

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,8 @@
 #     and the weekly cron cover the bases otherwise): create a fine-grained PAT
 #     scoped to `sbpp/sbpp.github.io` only with the `Actions: Read and write`
 #     repository permission, then register it on `sbpp/sourcebans-pp` as
-#     `secrets.DOCS_DEPLOY_PAT` and set `vars.DOCS_DEPLOY_ENABLED` to any
-#     non-empty value. The dispatcher there picks both up; no setup is needed
-#     in this repo.
+#     `secrets.DOCS_DEPLOY_PAT`. The dispatcher there picks it up; no setup
+#     is needed in this repo.
 
 name: Deploy docs to Pages
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,10 +8,11 @@
 # Triggers:
 #   - repository_dispatch (event type: docs-changed) — fired by
 #     `.github/workflows/docs-deploy-trigger.yml` in `sbpp/sourcebans-pp` after a
-#     push to main that touches `docs/**`. The dispatcher mints a short-lived
-#     installation token via the org-owned `sbpp-docs-deploy` GitHub App
-#     (Actions: write scope on this repo only) so we never need a PAT.
+#     push to main that touches `docs/**`. The dispatcher authenticates with a
+#     fine-grained PAT (`Actions: write` scope on this repo only) stored as
+#     `secrets.DOCS_DEPLOY_PAT` over there.
 #   - workflow_dispatch — manual button in the Actions UI for forced redeploys.
+#     Always available; no credentials needed (runs entirely inside this repo).
 #   - schedule (weekly Sunday) — safety net in case a dispatch is dropped, the
 #     upstream source is unreachable at dispatch time, or a previous deploy
 #     failed silently.
@@ -19,11 +20,13 @@
 # MANUAL SETUP REQUIRED (see issue #1333 cutover steps; cannot be configured in
 # workflow YAML):
 #   - Settings → Pages → Source must be set to "GitHub Actions" (UI-only).
-#   - The `sbpp-docs-deploy` GitHub App must exist with `Actions: write` scope on
-#     this repo, be installed on this repo, and have its App ID + private key
-#     registered as `vars.DOCS_DEPLOY_APP_ID` + `secrets.DOCS_DEPLOY_APP_KEY` in
-#     `sbpp/sourcebans-pp` (consumed by the dispatcher there — not by anything
-#     here).
+#   - For automatic deploys on docs PR merges (optional — `workflow_dispatch`
+#     and the weekly cron cover the bases otherwise): create a fine-grained PAT
+#     scoped to `sbpp/sbpp.github.io` only with the `Actions: Read and write`
+#     repository permission, then register it on `sbpp/sourcebans-pp` as
+#     `secrets.DOCS_DEPLOY_PAT` and set `vars.DOCS_DEPLOY_ENABLED` to any
+#     non-empty value. The dispatcher there picks both up; no setup is needed
+#     in this repo.
 
 name: Deploy docs to Pages
 


### PR DESCRIPTION
Followup to #54 + sbpp/sourcebans-pp#1347 (issue sbpp/sourcebans-pp#1333 cutover).

## What this PR changes

Comments only — no behavioral change to the deploy workflow.

The sibling sourcebans-pp dispatcher (`docs-deploy-trigger.yml`) is being switched from a GitHub App to a fine-grained PAT in sbpp/sourcebans-pp#1347. The deploy workflow in this repo doesn't change — it still listens for `repository_dispatch` events with `event_type: docs-changed` from anywhere, and whatever credential the dispatcher uses is invisible to us.

But the comment block above this workflow specifically mentions the App by name (`sbpp-docs-deploy`) and references the old `vars.DOCS_DEPLOY_APP_ID` + `secrets.DOCS_DEPLOY_APP_KEY` pair on the sourcebans-pp side. That would mislead anyone debugging the cutover after the sibling PR lands. This PR updates the comment to describe the PAT-based setup (`secrets.DOCS_DEPLOY_PAT` only — no paired feature-flag variable) and reframes it as **optional** — the `workflow_dispatch` button (manual) and weekly cron (safety net) on this repo cover the bases without any cross-repo credential at all.

## Diff

Pure comment churn. `python3 -c 'import yaml; yaml.safe_load(...)'` still parses.

## Merge order

This can land any time — independent of sbpp/sourcebans-pp#1347. The two PRs document the same cutover from different sides; merging either before the other won't break anything.