### PR TITLE
ci(deploy): bump Node to 22 for Astro >=22.12.0 requirement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,12 +96,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          # Match sibling `sourcebans-pp/.github/workflows/docs-build.yml`
-          # and the documented floor in `sourcebans-pp/docs/README.md`
-          # ("Node 20 LTS or newer"). Asymmetry between the validation
-          # gate and the deploy would mean a build that passes CI could
-          # still fail here.
-          node-version: '20'
+          # Astro requires Node >=22.12.0 (build fails on 20 with an
+          # explicit unsupported-engine error). Keep this in lockstep
+          # with sibling `sourcebans-pp/.github/workflows/docs-build.yml`
+          # and the documented floor in `sourcebans-pp/docs/README.md`:
+          # asymmetry between the validation gate and the deploy would
+          # mean a build that passes CI could still fail here.
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
 


### PR DESCRIPTION
## Summary
- Astro's build now fails on Node 20 with an explicit unsupported-engine error: `Node.js v20.20.2 is not supported by Astro! Please upgrade Node.js to a supported version: ">=22.12.0"`.
- Bump `actions/setup-node` input from `'20'` to `'22'` in `.github/workflows/deploy.yml` so the Pages deploy can build.
- Refresh the rationale comment to cite Astro's engine floor (not the old "Node 20 LTS or newer" framing).

## Follow-ups (separate repo)
Sibling `sbpp/sourcebans-pp` still pins Node 20 in:
- `.github/workflows/docs-build.yml` (validation gate)
- `docs/README.md` (documented floor)

Those need the same bump so the comment in this file stays truthful and the validation gate doesn't pass builds the deploy will reject.

## Test plan
- [ ] Merge, then trigger `workflow_dispatch` on `Deploy docs to Pages` and confirm `npm run build` succeeds.
- [ ] Verify the resulting Pages deploy renders correctly at https://sbpp.github.io/.